### PR TITLE
Changed set_shared_file to not return the path anymore (no longer needed)

### DIFF
--- a/main.py
+++ b/main.py
@@ -402,11 +402,12 @@ async def set_shared_file(tokenRequest: TokenRequest, db: db_dependency,
             return { "message" : False }
         else:
             xattr.setxattr(pathToWorkWith, "user.shareable", "True".encode())
-            async with aiofiles.open('key', 'rb') as keyFile:
-                key = await keyFile.read()
-            cipher = Fernet(key)
-            encryptedPath = cipher.encrypt(pathToEncrypt.encode())
-            return { "message" : "http://127.0.0.1:8000/file/" + encryptedPath.decode() }
+            # async with aiofiles.open('key', 'rb') as keyFile:
+            #     key = await keyFile.read()
+            # cipher = Fernet(key)
+            # encryptedPath = cipher.encrypt(pathToEncrypt.encode())
+            # return { "message" : "http://127.0.0.1:8000/file/" + encryptedPath.decode() }
+            return { "message" : True }
 
 # Endpoint for uploading files, for both guest and logged in user
 @app.post('/upload')


### PR DESCRIPTION
This pull request includes a significant change to the `set_shared_file` function in `main.py`. The change involves commenting out the encryption process and modifying the return message to a simple boolean value.

Key changes:

* [`main.py`](diffhunk://#diff-b10564ab7d2c520cdd0243874879fb0a782862c3c902ab535faabe57d5a505e1L405-R410): Commented out the encryption process using `Fernet` and modified the return message to `{ "message" : True }` instead of the encrypted file path.